### PR TITLE
all: fix sizeof, spurious spaces before/after brackets

### DIFF
--- a/include/e4/pstdint.h
+++ b/include/e4/pstdint.h
@@ -201,7 +201,7 @@ extern "C" {
  *  do nothing else.  On the Mac OS X version of gcc this is _STDINT_H_.
  */
 
-#if ((defined(__SUNPRO_C) && __SUNPRO_C >= 0x570) || (defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (__GNUC__ > 3 || defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)) )) && !defined (_PSTDINT_H_INCLUDED)
+#if ((defined(__SUNPRO_C) && __SUNPRO_C >= 0x570) || (defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (__GNUC__ > 3 || defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)))) && !defined (_PSTDINT_H_INCLUDED)
 #include <stdint.h>
 #define _PSTDINT_H_INCLUDED
 # if defined(__GNUC__) && (defined(__x86_64__) || defined(__ppc64__)) && !(defined(__APPLE__) && defined(__MACH__))
@@ -787,7 +787,7 @@ typedef uint_least32_t uint_fast32_t;
 #    define UINTPTR_C(x)                stdint_intptr_glue3(UINT,stdint_intptr_bits,_C)(x)
 #  endif
   typedef stdint_intptr_glue3(uint,stdint_intptr_bits,_t) uintptr_t;
-  typedef stdint_intptr_glue3( int,stdint_intptr_bits,_t)  intptr_t;
+  typedef stdint_intptr_glue3(int,stdint_intptr_bits,_t)  intptr_t;
 # else
 /* TODO -- This following is likely wrong for some platforms, and does
    nothing for the definition of uintptr_t. */
@@ -801,7 +801,7 @@ typedef uint_least32_t uint_fast32_t;
  */
 
 #ifndef SIG_ATOMIC_MAX
-# define SIG_ATOMIC_MAX ((((sig_atomic_t) 1) << (sizeof (sig_atomic_t)*CHAR_BIT-1)) - 1)
+# define SIG_ATOMIC_MAX ((((sig_atomic_t) 1) << (sizeof(sig_atomic_t)*CHAR_BIT-1)) - 1)
 #endif
 
 #endif
@@ -894,7 +894,7 @@ int main () {
 #endif
 
 #define STR(v) #v
-#define Q(v) printf ("sizeof " STR(v) " = %u\n", (unsigned) sizeof (v));
+#define Q(v) printf ("sizeof " STR(v) " = %u\n", (unsigned) sizeof(v));
 	if (err_n) {
 		printf ("pstdint.h is not correct.  Please use sizes below to correct it:\n");
 	}

--- a/include/e4/util.h
+++ b/include/e4/util.h
@@ -26,7 +26,7 @@ extern "C" {
 #define ZERO(X)                   \
     do                            \
     {                             \
-        zeroize(&X, sizeof X);    \
+        zeroize(&X, sizeof(X));    \
     } while (0)
 #endif
 

--- a/src/crypto/curve25519/curve25519-donna.c
+++ b/src/crypto/curve25519/curve25519-donna.c
@@ -707,7 +707,7 @@ swap_conditional(limb a[19], limb b[19], limb iswap) {
   const s32 swap = (s32) -iswap;
 
   for (i = 0; i < 10; ++i) {
-    const s32 x = swap & ( ((s32)a[i]) ^ ((s32)b[i]) );
+    const s32 x = swap & (((s32)a[i]) ^ ((s32)b[i]));
     a[i] = ((s32)a[i]) ^ x;
     b[i] = ((s32)b[i]) ^ x;
   }

--- a/src/crypto/ed25519/fixedint.h
+++ b/src/crypto/ed25519/fixedint.h
@@ -4,7 +4,7 @@
     Not a compatible replacement for <stdint.h>, do not blindly use it as such.
 */
 
-#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)) )) && !defined(FIXEDINT_H_INCLUDED)
+#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)))) && !defined(FIXEDINT_H_INCLUDED)
     #include <stdint.h>
     #define FIXEDINT_H_INCLUDED
 

--- a/src/crypto/sha512.c
+++ b/src/crypto/sha512.c
@@ -59,7 +59,7 @@ static const uint64_t K[80] = {
 /* Various logical functions */
 
 #define ROR64c(x, y) \
-    ( ((((x)&UINT64_C(0xFFFFFFFFFFFFFFFF))>>((uint64_t)(y)&UINT64_C(63))) | \
+    (((((x)&UINT64_C(0xFFFFFFFFFFFFFFFF))>>((uint64_t)(y)&UINT64_C(63))) | \
       ((x)<<((uint64_t)(64-((y)&UINT64_C(63)))))) & UINT64_C(0xFFFFFFFFFFFFFFFF))
 
 #define STORE64H(x, y)                                                                     \
@@ -84,7 +84,7 @@ static const uint64_t K[80] = {
 #define Gamma0(x)       (S(x, 1) ^ S(x, 8) ^ R(x, 7))
 #define Gamma1(x)       (S(x, 19) ^ S(x, 61) ^ R(x, 6))
 #ifndef MIN
-   #define MIN(x, y) ( ((x)<(y))?(x):(y) )
+   #define MIN(x, y) (((x)<(y))?(x):(y))
 #endif
 
 /* compress 1024-bits */

--- a/src/e4c_pk_store_file.c
+++ b/src/e4c_pk_store_file.c
@@ -76,19 +76,19 @@ int e4c_load(e4storage *store, const char *path)
         return E4_ERROR_PERSISTENCE_ERROR;
     }
 
-    memset(mbuf, 0, sizeof mbuf);
-    rlen = read(fd, mbuf, sizeof E4V2_MAGIC);
-    if (rlen != sizeof E4V2_MAGIC)
+    memset(mbuf, 0, sizeof(mbuf));
+    rlen = read(fd, mbuf, sizeof(E4V2_MAGIC));
+    if (rlen != sizeof(E4V2_MAGIC))
     {
         goto err;
     }
-    if (memcmp(mbuf, E4V2_MAGIC, sizeof E4V2_MAGIC) != 0)
+    if (memcmp(mbuf, E4V2_MAGIC, sizeof(E4V2_MAGIC)) != 0)
     {
         goto err;
     }
 
-    rlen = read(fd, store->id, sizeof store->id);
-    if (rlen != sizeof store->id)
+    rlen = read(fd, store->id, sizeof(store->id));
+    if (rlen != sizeof(store->id))
     {
         goto err;
     }
@@ -104,25 +104,25 @@ int e4c_load(e4storage *store, const char *path)
     e4c_derive_topichash(store->ctrltopic, E4_TOPICHASH_LEN, controltopic);
 
     /* read in key material */
-    rlen = read(fd, store->privkey, sizeof store->privkey);
-    if (rlen != sizeof store->privkey)
+    rlen = read(fd, store->privkey, sizeof(store->privkey));
+    if (rlen != sizeof(store->privkey))
     {
         goto err;
     }
-    rlen = read(fd, store->pubkey, sizeof store->pubkey);
-    if (rlen != sizeof store->pubkey)
+    rlen = read(fd, store->pubkey, sizeof(store->pubkey));
+    if (rlen != sizeof(store->pubkey))
     {
         goto err;
     }
     
-    rlen = read(fd, store->c2key, sizeof store->c2key);
-    if (rlen != sizeof store->c2key)
+    rlen = read(fd, store->c2key, sizeof(store->c2key));
+    if (rlen != sizeof(store->c2key))
     {
         goto err;
     }
 
-    rlen = read(fd, &store->topiccount, sizeof store->topiccount);
-    if (rlen != sizeof store->topiccount)
+    rlen = read(fd, &store->topiccount, sizeof(store->topiccount));
+    if (rlen != sizeof(store->topiccount))
     {
         goto err;
     }
@@ -145,8 +145,8 @@ int e4c_load(e4storage *store, const char *path)
         }
     }
     
-    rlen = read(fd, &store->devicecount, sizeof store->devicecount);
-    if (rlen != sizeof store->devicecount)
+    rlen = read(fd, &store->devicecount, sizeof(store->devicecount));
+    if (rlen != sizeof(store->devicecount))
     {
         goto err;
     }
@@ -195,28 +195,28 @@ int e4c_sync(e4storage *store)
         return E4_ERROR_PERSISTENCE_ERROR;
     }
 
-    write(fd, E4V2_MAGIC, sizeof E4V2_MAGIC);
-    write(fd, store->id, sizeof store->id);
-    write(fd, store->privkey, sizeof store->privkey);
-    write(fd, store->pubkey, sizeof store->pubkey);
-    write(fd, store->c2key, sizeof store->c2key);
-    write(fd, &store->topiccount, sizeof store->topiccount);
+    write(fd, E4V2_MAGIC, sizeof(E4V2_MAGIC));
+    write(fd, store->id, sizeof(store->id));
+    write(fd, store->privkey, sizeof(store->privkey));
+    write(fd, store->pubkey, sizeof(store->pubkey));
+    write(fd, store->c2key, sizeof(store->c2key));
+    write(fd, &store->topiccount, sizeof(store->topiccount));
 
     for (i = 0; i < store->topiccount; i++)
     {
         topic_key *t = &(store->topics[0]) + i;
 
-        write(fd, t->topic, sizeof t->topic);
-        write(fd, t->key, sizeof t->key);
+        write(fd, t->topic, sizeof(t->topic));
+        write(fd, t->key, sizeof(t->key));
     }
-    write(fd, &store->devicecount, sizeof store->devicecount);
+    write(fd, &store->devicecount, sizeof(store->devicecount));
 
     for (i = 0; i < store->devicecount; i++)
     {
         device_key *d = &(store->devices[0]) + i;
 
-        write(fd, d->id, sizeof d->id);
-        write(fd, d->pubkey, sizeof d->pubkey);
+        write(fd, d->id, sizeof(d->id));
+        write(fd, d->pubkey, sizeof(d->pubkey));
     }
     close(fd);
 
@@ -230,33 +230,33 @@ int e4c_set_id(e4storage *store, const uint8_t *id)
     ZERO(controltopic);
 
     r = e4c_derive_control_topic(controltopic, E4_CTRLTOPIC_LEN + 1, id);
-    if ( r != E4_RESULT_OK ) goto exit;
+    if (r != E4_RESULT_OK) goto exit;
 
     r = e4c_derive_topichash(store->ctrltopic, E4_TOPICHASH_LEN, controltopic);
-    if ( r != E4_RESULT_OK ) {
+    if (r != E4_RESULT_OK) {
         ZERO(store->ctrltopic);
         goto exit;
     }
 
-    memmove(store->id, id, sizeof store->id);
+    memmove(store->id, id, sizeof(store->id));
     r = E4_RESULT_OK;
 exit:
     return r;
 }
 int e4c_set_idseckey(e4storage *store, const uint8_t *key)
 {
-    memmove(store->privkey, key, sizeof store->privkey);
+    memmove(store->privkey, key, sizeof(store->privkey));
     e4c_sync(store);
     return E4_RESULT_OK;
 }
 
 int e4c_get_idseckey(e4storage* store, uint8_t *key) {
-    memcpy(key, store->privkey, sizeof store->privkey);
+    memcpy(key, store->privkey, sizeof(store->privkey));
     return 0;
 }
 
 int e4c_get_idpubkey(e4storage* store, uint8_t *key) {
-    memcpy(key, store->pubkey, sizeof store->pubkey);
+    memcpy(key, store->pubkey, sizeof(store->pubkey));
     return 0;
 }
 
@@ -362,7 +362,7 @@ int e4c_reset_topics(e4storage *store)
     {
         store->topiccount = 0;
     }
-    for ( i=0 ; i < E4_TOPICS_MAX ; i++ ) {
+    for (i=0 ; i < E4_TOPICS_MAX ; i++) {
         ZERO(store->topics[i]);
     }
 
@@ -371,7 +371,7 @@ int e4c_reset_topics(e4storage *store)
 }
 
 int e4c_set_idpubkey(e4storage *store, const uint8_t *pubkey) {
-    memmove(store->pubkey, pubkey, sizeof store->pubkey);
+    memmove(store->pubkey, pubkey, sizeof(store->pubkey));
     e4c_sync(store);
     return E4_RESULT_OK;
 }
@@ -460,7 +460,7 @@ int e4c_reset_devices(e4storage* store)
         store->devicecount = 0;
     }
     /* Attempt to zero memory. This may not work depending on the platform */
-    for ( i=0 ; i < E4_DEVICES_MAX ; i++ ) {
+    for (i=0 ; i < E4_DEVICES_MAX ; i++) {
         ZERO(store->devices[i]);
     }
 

--- a/src/e4c_pk_store_mem.c
+++ b/src/e4c_pk_store_mem.c
@@ -59,15 +59,15 @@ int e4c_set_id(e4storage *store, const uint8_t *id)
     ZERO(controltopic);
 
     r = e4c_derive_control_topic(controltopic, E4_CTRLTOPIC_LEN + 1, id);
-    if ( r != E4_RESULT_OK ) goto exit;
+    if (r != E4_RESULT_OK) goto exit;
 
     r = e4c_derive_topichash(store->ctrltopic, E4_TOPICHASH_LEN, controltopic);
-    if ( r != E4_RESULT_OK ) {
+    if (r != E4_RESULT_OK) {
         ZERO(store->ctrltopic);
         goto exit;
     }
 
-    memmove(store->id, id, sizeof store->id);
+    memmove(store->id, id, sizeof(store->id));
     r = E4_RESULT_OK;
 exit:
     return r;
@@ -75,18 +75,18 @@ exit:
 
 int e4c_set_idseckey(e4storage *store, const uint8_t *key)
 {
-    memmove(store->privkey, key, sizeof store->privkey);
+    memmove(store->privkey, key, sizeof(store->privkey));
     e4c_sync(store);
     return E4_RESULT_OK;
 }
 
 int e4c_get_idseckey(e4storage* store, uint8_t *key) {
-    memcpy(key, store->privkey, sizeof store->privkey);
+    memcpy(key, store->privkey, sizeof(store->privkey));
     return 0;
 }
 
 int e4c_get_idpubkey(e4storage* store, uint8_t *key) {
-    memcpy(key, store->pubkey, sizeof store->pubkey);
+    memcpy(key, store->pubkey, sizeof(store->pubkey));
     return 0;
 }
 
@@ -192,7 +192,7 @@ int e4c_reset_topics(e4storage *store)
     {
         store->topiccount = 0;
     }
-    for ( i=0 ; i < E4_TOPICS_MAX ; i++ ) {
+    for (i=0 ; i < E4_TOPICS_MAX ; i++) {
         ZERO(store->topics[i]);
     }
 
@@ -201,7 +201,7 @@ int e4c_reset_topics(e4storage *store)
 }
 
 int e4c_set_idpubkey(e4storage *store, const uint8_t *pubkey) {
-    memmove(store->pubkey, pubkey, sizeof store->pubkey);
+    memmove(store->pubkey, pubkey, sizeof(store->pubkey));
     e4c_sync(store);
     return E4_RESULT_OK;
 }
@@ -290,7 +290,7 @@ int e4c_reset_devices(e4storage* store)
         store->devicecount = 0;
     }
     /* Attempt to zero memory. This may not work depending on the platform */
-    for ( i=0 ; i < E4_DEVICES_MAX ; i++ ) {
+    for (i=0 ; i < E4_DEVICES_MAX ; i++) {
         ZERO(store->devices[i]);
     }
 

--- a/src/e4c_store_file.c
+++ b/src/e4c_store_file.c
@@ -72,20 +72,20 @@ int e4c_load(e4storage *store, const char *path)
         return E4_ERROR_PERSISTENCE_ERROR;
     }
 
-    memset(mbuf, 0, sizeof mbuf);
-    rlen = read(fd, mbuf, sizeof E4V1_MAGIC);
-    if (rlen != sizeof E4V1_MAGIC)
+    memset(mbuf, 0, sizeof(mbuf));
+    rlen = read(fd, mbuf, sizeof(E4V1_MAGIC));
+    if (rlen != sizeof(E4V1_MAGIC))
     {
         goto err;
     }
-    if (memcmp(mbuf, E4V1_MAGIC, sizeof E4V1_MAGIC) != 0)
+    if (memcmp(mbuf, E4V1_MAGIC, sizeof(E4V1_MAGIC)) != 0)
     {
         goto err;
     }
 
 
-    rlen = read(fd, store->id, sizeof store->id);
-    if (rlen != sizeof store->id)
+    rlen = read(fd, store->id, sizeof(store->id));
+    if (rlen != sizeof(store->id))
     {
         goto err;
     }
@@ -100,15 +100,15 @@ int e4c_load(e4storage *store, const char *path)
     /* derive a topichash for the control topic. */
     e4c_derive_topichash(store->ctrltopic, E4_TOPICHASH_LEN, controltopic);
 
-    rlen = read(fd, store->key, sizeof store->key);
-    if (rlen != sizeof store->key)
+    rlen = read(fd, store->key, sizeof(store->key));
+    if (rlen != sizeof(store->key))
     {
         goto err;
     }
 
 
-    rlen = read(fd, &store->topiccount, sizeof store->topiccount);
-    if (rlen != sizeof store->topiccount)
+    rlen = read(fd, &store->topiccount, sizeof(store->topiccount));
+    if (rlen != sizeof(store->topiccount))
     {
         goto err;
     }
@@ -160,17 +160,17 @@ int e4c_sync(e4storage *store)
         return E4_ERROR_PERSISTENCE_ERROR;
     }
 
-    write(fd, E4V1_MAGIC, sizeof E4V1_MAGIC);
-    write(fd, store->id, sizeof store->id);
-    write(fd, store->key, sizeof store->key);
-    write(fd, &store->topiccount, sizeof store->topiccount);
+    write(fd, E4V1_MAGIC, sizeof(E4V1_MAGIC));
+    write(fd, store->id, sizeof(store->id));
+    write(fd, store->key, sizeof(store->key));
+    write(fd, &store->topiccount, sizeof(store->topiccount));
 
     for (i = 0; i < store->topiccount; i++)
     {
         topic_key *t = &(store->topics[0]) + i;
 
-        write(fd, t->topic, sizeof t->topic);
-        write(fd, t->key, sizeof t->key);
+        write(fd, t->topic, sizeof(t->topic));
+        write(fd, t->key, sizeof(t->key));
     }
     close(fd);
 
@@ -184,15 +184,15 @@ int e4c_set_id(e4storage *store, const uint8_t *id)
     ZERO(controltopic);
 
     r = e4c_derive_control_topic(controltopic, E4_CTRLTOPIC_LEN + 1, id);
-    if ( r != E4_RESULT_OK ) goto exit;
+    if (r != E4_RESULT_OK) goto exit;
 
     r = e4c_derive_topichash(store->ctrltopic, E4_TOPICHASH_LEN, controltopic);
-    if ( r != E4_RESULT_OK ) {
+    if (r != E4_RESULT_OK) {
         ZERO(store->ctrltopic);
         goto exit;
     }
 
-    memmove(store->id, id, sizeof store->id);
+    memmove(store->id, id, sizeof(store->id));
     r = E4_RESULT_OK;
 exit:
     return r;
@@ -200,7 +200,7 @@ exit:
 
 int e4c_set_idkey(e4storage *store, const uint8_t *key)
 {
-    memmove(store->key, key, sizeof store->key);
+    memmove(store->key, key, sizeof(store->key));
     return E4_RESULT_OK;
 }
 

--- a/src/e4c_store_mem.c
+++ b/src/e4c_store_mem.c
@@ -60,15 +60,15 @@ int e4c_set_id(e4storage *store, const uint8_t *id)
     ZERO(controltopic);
 
     r = e4c_derive_control_topic(controltopic, E4_CTRLTOPIC_LEN + 1, id);
-    if ( r != E4_RESULT_OK ) goto exit;
+    if (r != E4_RESULT_OK) goto exit;
 
     r = e4c_derive_topichash(store->ctrltopic, E4_TOPICHASH_LEN, controltopic);
-    if ( r != E4_RESULT_OK ) {
+    if (r != E4_RESULT_OK) {
         ZERO(store->ctrltopic);
         goto exit;
     }
 
-    memmove(store->id, id, sizeof store->id);
+    memmove(store->id, id, sizeof(store->id));
     r = E4_RESULT_OK;
 exit:
     return r;
@@ -77,7 +77,7 @@ exit:
 
 int e4c_set_idkey(e4storage *store, const uint8_t *key)
 {
-    memmove(store->key, key, sizeof store->key);
+    memmove(store->key, key, sizeof(store->key));
     return E4_RESULT_OK;
 }
 

--- a/src/e4pkcclient.c
+++ b/src/e4pkcclient.c
@@ -127,7 +127,7 @@ int e4c_protect_message(uint8_t *cptr,
     /* pubkey messages are: Timestamp (8) | id (16) | IV (16) | Ciphertext (n) | sig (64) */
     /* safety check. clen_siv = msglen+E4_TAG_LEN. Therefore adding E4_PK_EDDSA_SIG_LEN + E4_TIMESTAMP_LEN + E4_ID_LEN should 
      * equal clen */
-    if ( *clen != clen_siv + E4_PK_EDDSA_SIG_LEN + E4_TIMESTAMP_LEN + E4_ID_LEN ) {
+    if (*clen != clen_siv + E4_PK_EDDSA_SIG_LEN + E4_TIMESTAMP_LEN + E4_ID_LEN) {
         return E4_ERROR_INTERNAL;
     }
 
@@ -181,9 +181,9 @@ int e4c_unprotect_message(uint8_t *mptr,
         uint8_t devicesk[E4_PK_X25519_PUBKEY_LEN];
         uint8_t sharedpoint[E4_PK_X25519_PUBKEY_LEN];
 
-        memset(c2pk, 0, sizeof c2pk);
-        memset(devicesk, 0, sizeof devicesk);
-        memset(sharedpoint, 0, sizeof sharedpoint);
+        memset(c2pk, 0, sizeof(c2pk));
+        memset(devicesk, 0, sizeof(devicesk));
+        memset(sharedpoint, 0, sizeof(sharedpoint));
         /* control topic being used: */
         control = 1;
 
@@ -194,7 +194,7 @@ int e4c_unprotect_message(uint8_t *mptr,
         }
 
         r = e4c_get_c2_pubkey(storage, c2pk);
-        if ( r != E4_RESULT_OK ) {
+        if (r != E4_RESULT_OK) {
             return r;
         }
         e4c_get_idseckey(storage, deviceedsk);
@@ -258,7 +258,7 @@ int e4c_unprotect_message(uint8_t *mptr,
              * have a key at all for a client, signature verification 
              * must succeed. This option is a get-out for when we cannot 
              * store keys due to storage constraints */
-            if ( !(proto_opts & E4_OPTION_IGNORE_MISSING_PUBKEY) ) {
+            if (!(proto_opts & E4_OPTION_IGNORE_MISSING_PUBKEY)) {
                 return E4_ERROR_DEVICEPK_MISSING;
             }
         }
@@ -319,7 +319,7 @@ int e4c_unprotect_message(uint8_t *mptr,
     else
     {
 
-        if (!(proto_opts & E4_OPTION_IGNORE_TIMESTAMP )) {   
+        if (!(proto_opts & E4_OPTION_IGNORE_TIMESTAMP)) {   
             if (tstamp >= secs1970)
             {
                 if (tstamp - secs1970 > E4C_TIME_FUTURE)

--- a/src/e4symclient.c
+++ b/src/e4symclient.c
@@ -97,7 +97,7 @@ int e4c_protect_message(uint8_t *cptr,
     *clen += E4_TIMESTAMP_LEN;
 
     /* safety check */
-    if ( *clen != mlen + E4_MSGHDR_LEN ) {
+    if (*clen != mlen + E4_MSGHDR_LEN) {
         return E4_ERROR_INTERNAL;
     }
 
@@ -186,7 +186,7 @@ int e4c_unprotect_message(uint8_t *mptr,
     }
     else
     {
-        if (!(proto_opts & E4_OPTION_IGNORE_TIMESTAMP )) {   
+        if (!(proto_opts & E4_OPTION_IGNORE_TIMESTAMP)) {   
             if (tstamp >= secs1970)
             {
                 if (tstamp - secs1970 > E4C_TIME_FUTURE)

--- a/src/e4util.c
+++ b/src/e4util.c
@@ -24,15 +24,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-void zeroize( void *v, size_t n )
+void zeroize(void *v, size_t n)
 {
-    volatile unsigned char *p = ( volatile unsigned char * )v;
-    while( n-- ) *p++ = 0;
+    volatile unsigned char *p = (volatile unsigned char *)v;
+    while(n--) *p++ = 0;
 }
 
 int e4c_derive_clientid(uint8_t *clientid, const size_t clientidlen, const char *clientname, const size_t clientnamelen)
 {
-    if (clientidlen != E4_ID_LEN ) {
+    if (clientidlen != E4_ID_LEN) {
         return E4_ID_LEN;
     }
     sha3_256_trunc((char*)clientid, clientidlen, clientname, clientnamelen);
@@ -41,7 +41,6 @@ int e4c_derive_clientid(uint8_t *clientid, const size_t clientidlen, const char 
 
 int e4c_derive_control_topic(char *topic, const size_t topiclen, const uint8_t *clientid)
 {
-
     int i = 0;
 
     if (topiclen < E4_CTRLTOPIC_LEN + 1)
@@ -52,7 +51,7 @@ int e4c_derive_control_topic(char *topic, const size_t topiclen, const uint8_t *
 #if __STDC_VERSION__ >= 199901L
     snprintf(topic, topiclen, "e4/");
 #else
-    if ( topiclen < 3 ) {
+    if (topiclen < 3) {
         return -1;
     }
     sprintf(topic, "e4/");
@@ -63,7 +62,7 @@ int e4c_derive_control_topic(char *topic, const size_t topiclen, const uint8_t *
     #if __STDC_VERSION__ >= 199901L
         snprintf((char *)(topic + adjust), topiclen - adjust, "%02x", clientid[i]);
     #else
-        if ( adjust >= topiclen ) {
+        if (adjust >= topiclen) {
             return -1;
         }
         sprintf((char *)(topic + adjust), "%02x", clientid[i]);
@@ -76,7 +75,7 @@ int e4c_derive_control_topic(char *topic, const size_t topiclen, const uint8_t *
 /* Computes the topichash, which is currently SHA3-256/128. */
 int e4c_derive_topichash(uint8_t* topichash, const size_t topichash_len, const char* topic) {
     size_t topiclen = strlen(topic);
-    if (topichash_len != E4_ID_LEN ) {
+    if (topichash_len != E4_ID_LEN) {
         return E4_ID_LEN;
     }
     sha3_256_trunc((char*)topichash, topichash_len, topic, topiclen);

--- a/test/pubkey/pubkey_crypto_test.c
+++ b/test/pubkey/pubkey_crypto_test.c
@@ -21,7 +21,7 @@ void printhex(const uint8_t* buffer, size_t len)
 
 int main(int argc, char** argv) {
 
-    for ( int i = 0; i < NUM_PKCATS; i++ )
+    for (int i = 0; i < NUM_PKCATS; i++)
     {
     // point conversion tests:
     
@@ -29,9 +29,9 @@ int main(int argc, char** argv) {
     xed25519_convert_ed2c_private(c2_c255_private, pkkat[0].c2_edwards_seckey);
     if (memcmp(c2_c255_private, pkkat[0].c2_montgom_seckey, 32) != 0) {
         printf("c25519_privkey_convert failed.\n");
-        printhex(c2_c255_private, sizeof c2_c255_private);
+        printhex(c2_c255_private, sizeof(c2_c255_private));
         printf("\n");
-        printhex(pkkat[0].c2_montgom_seckey, sizeof pkkat[0].c2_montgom_seckey);
+        printhex(pkkat[0].c2_montgom_seckey, sizeof(pkkat[0].c2_montgom_seckey));
         printf("\n");
 
         //return 1;
@@ -41,15 +41,15 @@ int main(int argc, char** argv) {
 
     uint8_t c2_c255_pubkey[32] = {0};
 
-    if (xed25519_convert_ed2c_public(c2_c255_pubkey, pkkat[0].c2_edwards_pubkey) != XED25519_RESULT_OK ) {
+    if (xed25519_convert_ed2c_public(c2_c255_pubkey, pkkat[0].c2_edwards_pubkey) != XED25519_RESULT_OK) {
         
         printf("c25519_pubkey_convert error reported from decode.\n");
     }
     if (memcmp(c2_c255_pubkey, pkkat[0].c2_montgom_pubkey, 32) != 0) {
         printf("c25519_privkey_convert failed.\n");
-        printhex(c2_c255_pubkey, sizeof c2_c255_pubkey);
+        printhex(c2_c255_pubkey, sizeof(c2_c255_pubkey));
         printf("\n");
-        printhex(pkkat[0].c2_montgom_pubkey, sizeof pkkat[0].c2_montgom_pubkey);
+        printhex(pkkat[0].c2_montgom_pubkey, sizeof(pkkat[0].c2_montgom_pubkey));
         printf("\n");
 
         //return 1;
@@ -63,15 +63,15 @@ int main(int argc, char** argv) {
     uint8_t c255_shared_secret[32] = {0};
 
     curve25519(c255_shared_point, pkkat[0].c2_montgom_seckey, pkkat[0].dev_montgom_pubkey);
-    sha3(c255_shared_point, sizeof c255_shared_point, c255_shared_secret, sizeof c255_shared_secret);
+    sha3(c255_shared_point, sizeof(c255_shared_point), c255_shared_secret, sizeof(c255_shared_secret));
     
     if (memcmp(c255_shared_secret, pkkat[0].c2_sharedkey, 32) != 0) {
         printf("c25519_kex failed.\n");
-        printhex(c255_shared_secret, sizeof c255_shared_secret);
+        printhex(c255_shared_secret, sizeof(c255_shared_secret));
         printf("\n");
-        printhex(pkkat[0].c2_sharedkey, sizeof pkkat[0].c2_sharedkey);
+        printhex(pkkat[0].c2_sharedkey, sizeof(pkkat[0].c2_sharedkey));
         printf("\n");
-        printhex(pkkat[0].dev_sharedkey, sizeof pkkat[0].dev_sharedkey);
+        printhex(pkkat[0].dev_sharedkey, sizeof(pkkat[0].dev_sharedkey));
         printf("\n");
 
         //return 1;
@@ -81,19 +81,19 @@ int main(int argc, char** argv) {
     
     // curve25519 variant c2->device:
     
-    memset(c255_shared_secret, 0, sizeof c255_shared_secret);
-    memset(c255_shared_point, 0, sizeof c255_shared_point);
+    memset(c255_shared_secret, 0, sizeof(c255_shared_secret));
+    memset(c255_shared_point, 0, sizeof(c255_shared_point));
 
     curve25519(c255_shared_point, pkkat[0].dev_montgom_seckey, pkkat[0].c2_montgom_pubkey);
-    sha3(c255_shared_point, sizeof c255_shared_point, c255_shared_secret, sizeof c255_shared_secret);
+    sha3(c255_shared_point, sizeof(c255_shared_point), c255_shared_secret, sizeof(c255_shared_secret));
     
     if (memcmp(c255_shared_secret, pkkat[0].dev_sharedkey, 32) != 0) {
         printf("c25519_kex failed.\n");
-        printhex(c255_shared_secret, sizeof c255_shared_secret);
+        printhex(c255_shared_secret, sizeof(c255_shared_secret));
         printf("\n");
-        printhex(pkkat[0].c2_sharedkey, sizeof pkkat[0].c2_sharedkey);
+        printhex(pkkat[0].c2_sharedkey, sizeof(pkkat[0].c2_sharedkey));
         printf("\n");
-        printhex(pkkat[0].dev_sharedkey, sizeof pkkat[0].dev_sharedkey);
+        printhex(pkkat[0].dev_sharedkey, sizeof(pkkat[0].dev_sharedkey));
         printf("\n");
 
         //return 1;

--- a/test/pubkey/pubkey_e4cmd_test.c
+++ b/test/pubkey/pubkey_e4cmd_test.c
@@ -27,20 +27,20 @@ int main(int argc, char** argv, char** envp) {
     uint8_t messagebuffer[100];
     char ctrltopic[E4_CTRLTOPIC_LEN+1] = {0};
 
-    memset(&store, 0, sizeof store);
+    memset(&store, 0, sizeof(store));
 
     urand_fd = fopen("/dev/urandom", "r");
-    if ( urand_fd == NULL  ) {
+    if (urand_fd == NULL) {
         /* can't generate random plaintexts in this case */
         printf("Failed: unable to open /dev/urandom\n");
         returncode = 1;
         goto exit;
     }
 
-    for ( int i = 0; i < NUM_PKCATS; i++ ) {
+    for (int i = 0; i < NUM_PKCATS; i++) {
 
         e4retcode = e4c_init(&store);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to init e4store\n");
             returncode = 1;
             goto exit_close;
@@ -49,33 +49,33 @@ int main(int argc, char** argv, char** envp) {
         e4c_set_storagelocation(&store, "/tmp/unittestspk_cmd.e4c");
 
         e4retcode = e4c_set_id(&store, pkkat[i].deviceid);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set id\n");
             returncode = 1;
             goto exit_close;
         }
 
         e4retcode = e4c_set_idseckey(&store, pkkat[i].dev_edwards_seckey);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set idseckey\n");
             returncode = 1;
             goto exit_close;
         }
         e4retcode = e4c_set_idpubkey(&store, pkkat[i].dev_edwards_pubkey);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set idpubkey\n");
             returncode = 1;
             goto exit_close;
         }
 
         /* let's check this also works */
-        if ( memcmp(store.pubkey, pkkat[i].dev_edwards_pubkey, sizeof pkkat[i].dev_edwards_pubkey) != 0 )
+        if (memcmp(store.pubkey, pkkat[i].dev_edwards_pubkey, sizeof(pkkat[i].dev_edwards_pubkey)) != 0)
         {
             printf("Failed: did not correctly store device pubkey.\n");
             returncode = 1;
             goto exit_close;
         }
-        if ( memcmp(store.privkey, pkkat[i].dev_edwards_seckey, sizeof pkkat[i].dev_edwards_seckey) != 0 )
+        if (memcmp(store.privkey, pkkat[i].dev_edwards_seckey, sizeof(pkkat[i].dev_edwards_seckey)) != 0)
         {
             printf("Failed: did not correctly store device pubkey.\n");
             returncode = 1;
@@ -83,7 +83,7 @@ int main(int argc, char** argv, char** envp) {
         }
 
         e4retcode = e4c_set_c2_pubkey(&store, pkkat[i].c2_montgom_pubkey);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set c2 pubkey\n");
             returncode = 1;
             goto exit_close;
@@ -91,28 +91,28 @@ int main(int argc, char** argv, char** envp) {
 
         uint8_t c2pk[E4_PK_X25519_PUBKEY_LEN] = {0};
         e4retcode = e4c_get_c2_pubkey(&store, c2pk);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set c2 pubkey\n");
             returncode = 1;
             goto exit_close;
         }
-        if ( memcmp(c2pk, pkkat[i].c2_montgom_pubkey, sizeof pkkat[i].c2_montgom_pubkey) != 0 ) {
+        if (memcmp(c2pk, pkkat[i].c2_montgom_pubkey, sizeof(pkkat[i].c2_montgom_pubkey)) != 0) {
             printf("Failed: unable to retrieve c2 pubkey we set. Data is corrupted.\n");
             returncode = 1;
             goto exit_close;
         }
 
-        if ( e4c_derive_control_topic(ctrltopic, E4_CTRLTOPIC_LEN+1, pkkat[i].deviceid) != 0 ) {
+        if (e4c_derive_control_topic(ctrltopic, E4_CTRLTOPIC_LEN+1, pkkat[i].deviceid) != 0) {
             printf("Failed: unable to derive control topic\n");
             returncode = 1;
             goto exit_close;
         }
         /* now we are set up, let's try processing those command messages */
 
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         messagelen = 0;
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           pkkat[i].cmd_resettopics,
                           pkkat[i].cmd_resettopics_len,
@@ -120,7 +120,7 @@ int main(int argc, char** argv, char** envp) {
                           &store,
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK_CONTROL ) {
+        if (e4retcode != E4_RESULT_OK_CONTROL) {
             printf("Failed: e4c_unprotect_message returned error code other than 'this is a command'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : command is resettopics\n");
@@ -129,10 +129,10 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         messagelen = 0;
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           pkkat[i].cmd_settopickey,
                           pkkat[i].cmd_settopickey_len,
@@ -140,7 +140,7 @@ int main(int argc, char** argv, char** envp) {
                           &store,
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK_CONTROL ) {
+        if (e4retcode != E4_RESULT_OK_CONTROL) {
             printf("Failed: e4c_unprotect_message returned error code other than 'this is a command'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : command is settopickey\n");
@@ -149,10 +149,10 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         messagelen = 0;
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           pkkat[i].cmd_removetopic,
                           pkkat[i].cmd_removetopic_len,
@@ -160,7 +160,7 @@ int main(int argc, char** argv, char** envp) {
                           &store,
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK_CONTROL ) {
+        if (e4retcode != E4_RESULT_OK_CONTROL) {
             printf("Failed: e4c_unprotect_message returned error code other than 'this is a command'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : command is removetopic\n");
@@ -169,10 +169,10 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         messagelen = 0;
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           pkkat[i].cmd_resetpubkeys,
                           pkkat[i].cmd_resetpubkeys_len,
@@ -180,7 +180,7 @@ int main(int argc, char** argv, char** envp) {
                           &store,
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK_CONTROL ) {
+        if (e4retcode != E4_RESULT_OK_CONTROL) {
             printf("Failed: e4c_unprotect_message returned error code other than 'this is a command'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : command is resetpubkeys\n");
@@ -189,10 +189,10 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         messagelen = 0;
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           pkkat[i].cmd_setpubkey,
                           pkkat[i].cmd_setpubkey_len,
@@ -200,7 +200,7 @@ int main(int argc, char** argv, char** envp) {
                           &store, 
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK_CONTROL ) {
+        if (e4retcode != E4_RESULT_OK_CONTROL) {
             printf("Failed: e4c_unprotect_message returned error code other than 'this is a command'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : command is setpubkey\n");
@@ -209,10 +209,10 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         messagelen = 0;
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           pkkat[i].cmd_removepubkey,
                           pkkat[i].cmd_removepubkey_len,
@@ -220,7 +220,7 @@ int main(int argc, char** argv, char** envp) {
                           &store, 
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK_CONTROL ) {
+        if (e4retcode != E4_RESULT_OK_CONTROL) {
             printf("Failed: e4c_unprotect_message returned error code other than 'this is a command'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : command is removepubkey\n");

--- a/test/pubkey/pubkey_e4topicmsg_test.c
+++ b/test/pubkey/pubkey_e4topicmsg_test.c
@@ -27,10 +27,10 @@ int main(int argc, char** argv, char** envp) {
     uint8_t messagebuffer[33]; /* e4c_unprotect leaves an additional 0 */
     char ctrltopic[E4_CTRLTOPIC_LEN+1] = {0};
 
-    memset(&store, 0, sizeof store);
+    memset(&store, 0, sizeof(store));
 
     urand_fd = fopen("/dev/urandom", "r");
-    if ( urand_fd == NULL  ) {
+    if (urand_fd == NULL) {
         /* can't generate random plaintexts in this case */
         printf("Failed: unable to open /dev/urandom\n");
         returncode = 1;
@@ -38,7 +38,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     e4retcode = e4c_init(&store);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to init e4store\n");
             returncode = 1;
             goto exit_close;
@@ -47,27 +47,27 @@ int main(int argc, char** argv, char** envp) {
         e4c_set_storagelocation(&store, "/tmp/unittestspk_topic.e4c");
 
         e4retcode = e4c_set_id(&store, pkkat[0].deviceid);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set id\n");
             returncode = 1;
             goto exit_close;
         }
 
         e4retcode = e4c_set_idseckey(&store, pkkat[0].dev_edwards_seckey);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set idseckey\n");
             returncode = 1;
             goto exit_close;
         }
         e4retcode = e4c_set_idpubkey(&store, pkkat[0].dev_edwards_pubkey);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set idpubkey\n");
             returncode = 1;
             goto exit_close;
         }
 
         e4retcode = e4c_set_c2_pubkey(&store, pkkat[0].c2_montgom_pubkey);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set c2 pubkey\n");
             returncode = 1;
             goto exit_close;
@@ -75,29 +75,29 @@ int main(int argc, char** argv, char** envp) {
 
         uint8_t c2pk[E4_PK_X25519_PUBKEY_LEN] = {0};
         e4retcode = e4c_get_c2_pubkey(&store, c2pk);
-        if ( e4retcode != 0 ) {
+        if (e4retcode != 0) {
             printf("Failed: unable to set c2 pubkey\n");
             returncode = 1;
             goto exit_close;
         }
-        if ( memcmp(c2pk, pkkat[0].c2_montgom_pubkey, sizeof pkkat[0].c2_montgom_pubkey) != 0 ) {
+        if (memcmp(c2pk, pkkat[0].c2_montgom_pubkey, sizeof(pkkat[0].c2_montgom_pubkey)) != 0) {
             printf("Failed: unable to retrieve c2 pubkey we set. Data is corrupted.\n");
             returncode = 1;
             goto exit_close;
         }
 
-        if ( e4c_derive_control_topic(ctrltopic, E4_CTRLTOPIC_LEN+1, pkkat[0].deviceid) != 0 ) {
+        if (e4c_derive_control_topic(ctrltopic, E4_CTRLTOPIC_LEN+1, pkkat[0].deviceid) != 0) {
             printf("Failed: unable to derive control topic\n");
             returncode = 1;
             goto exit_close;
         }
 
-    for ( int i = 0; i < NUM_TOPICCATS; i++ ) {
+    for (int i = 0; i < NUM_TOPICCATS; i++) {
 
 
         unsigned char topichash[E4_TOPICHASH_LEN] = {0};
 
-        if ( e4c_set_device_key(&store, topickat[i].otherdevice_id, topickat[i].otherdevice_pubkey) != E4_RESULT_OK ) {
+        if (e4c_set_device_key(&store, topickat[i].otherdevice_id, topickat[i].otherdevice_pubkey) != E4_RESULT_OK) {
             printf("Unable to set device key");
             returncode = 1;
             goto exit_close;
@@ -106,17 +106,17 @@ int main(int argc, char** argv, char** envp) {
         e4c_derive_topichash(topichash, E4_TOPICHASH_LEN, topickat[i].topicname);
         e4c_set_topic_key(&store, topichash, topickat[i].topickey);
         
-        memset(messagebuffer, 0, sizeof messagebuffer);
+        memset(messagebuffer, 0, sizeof(messagebuffer));
         e4retcode = e4c_unprotect_message(messagebuffer,
-                          sizeof messagebuffer,
+                          sizeof(messagebuffer),
                           &messagelen,
                           topickat[i].e4_ciphertext,
-                          sizeof topickat[i].e4_ciphertext,
+                          sizeof(topickat[i].e4_ciphertext),
                           topickat[i].topicname,
                           &store,
                           E4_OPTION_IGNORE_TIMESTAMP);
 
-        if ( e4retcode != E4_RESULT_OK ) {
+        if (e4retcode != E4_RESULT_OK) {
             printf("Failed: e4c_unprotect_message returned error code other than 'OK'\n");
             printf("      : return code was %d\n", e4retcode);
             printf("      : test instance is %d\n", i);
@@ -124,19 +124,19 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
         
-        if ( memcmp(messagebuffer, topickat[i].plaintext, sizeof topickat[i].plaintext) != 0 ) {
+        if (memcmp(messagebuffer, topickat[i].plaintext, sizeof(topickat[i].plaintext)) != 0) {
             printf("Failed: decrypted plaintext not equal to KAT.\n");
             returncode = 1;
             goto exit_close;
         }
         
         e4retcode = e4c_remove_device(&store, topickat[i].otherdevice_id);
-        if ( e4retcode != E4_RESULT_OK ) {
+        if (e4retcode != E4_RESULT_OK) {
 #ifdef DEBUG
             e4c_debug_print(&store);
 #endif
             printf("ID: ");
-            for ( int j = 0; j < E4_ID_LEN; j++ ) {
+            for (int j = 0; j < E4_ID_LEN; j++) {
                 printf("%02x ", topickat[i].otherdevice_id[j]);
             }
             printf("\n");

--- a/test/pubkey/pubkey_filestore_test.c
+++ b/test/pubkey/pubkey_filestore_test.c
@@ -30,10 +30,10 @@ int main(int argc, char** argv, char** envp) {
     unsigned char topichash[E4_TOPICHASH_LEN];
     char topics[NUM_TOPICS][SIZE_TOPICNAME+1];
 
-    memset(&store, 0, sizeof store);
+    memset(&store, 0, sizeof(store));
 
     urand_fd = fopen("/dev/urandom", "r");
-    if ( urand_fd == NULL  ) {
+    if (urand_fd == NULL) {
         /* can't generate random plaintexts in this case */
         printf("Failed: unable to open /dev/urandom\n");
         returncode = 1;
@@ -41,7 +41,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     e4retcode = e4c_init(&store);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to init e4store\n");
         returncode = 1;
         goto exit_close;
@@ -50,57 +50,57 @@ int main(int argc, char** argv, char** envp) {
     e4c_set_storagelocation(&store, "/tmp/unittestspk.e4c");
 
     e4retcode = e4c_set_id(&store, pkkat[0].deviceid);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to set id\n");
         returncode = 1;
         goto exit_close;
     }
     
     e4retcode = e4c_set_idseckey(&store, pkkat[0].dev_edwards_seckey);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to set idseckey\n");
         returncode = 1;
         goto exit_close;
     }
     e4retcode = e4c_set_idpubkey(&store, pkkat[0].dev_edwards_pubkey);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to set idpubkey\n");
         returncode = 1;
         goto exit_close;
     }
     e4retcode = e4c_set_c2_pubkey(&store, pkkat[0].c2_edwards_pubkey);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to set c2 pubkey\n");
         returncode = 1;
         goto exit_close;
     }
 
-    for ( iteration = 0; iteration<NUM_TOPICS; iteration++ ) {
+    for (iteration = 0; iteration<NUM_TOPICS; iteration++) {
 
         int j=0;
 
         memset(topics[iteration], 0, SIZE_TOPICNAME);
-        memset(topicname_current, 0, sizeof topicname_current);
-        memset(topickey_current, 0, sizeof topickey_current);
+        memset(topicname_current, 0, sizeof(topicname_current));
+        memset(topickey_current, 0, sizeof(topickey_current));
 
-        bytes_read = fread(topickey_current, 1, sizeof topickey_current, urand_fd);
-        if ( bytes_read < sizeof topickey_current ) {
-            printf("Failed: generating topickey_current bytes read %lu, expected %lu\n", bytes_read, sizeof topickey_current);
+        bytes_read = fread(topickey_current, 1, sizeof(topickey_current), urand_fd);
+        if (bytes_read < sizeof(topickey_current)) {
+            printf("Failed: generating topickey_current bytes read %lu, expected %lu\n", bytes_read, sizeof(topickey_current));
             returncode = 4;
             goto exit_close;
         }
         bytes_read = fread(topicname_tmp, 1, SIZE_TOPICNAME/2, urand_fd);
-        if ( bytes_read < sizeof topicname_tmp ) {
+        if (bytes_read < sizeof(topicname_tmp)) {
             printf("Failed: generating topicname bytes read %lu, expected %lu\n", bytes_read, SIZE_TOPICNAME/2);
             returncode = 5;
             goto exit_close;
         }
 
-        for ( j = 0; j < SIZE_TOPICNAME/2; j++ ) {
-            snprintf(&topicname_current[2*j], (sizeof topicname_current)-(2*j), "%02x", topicname_tmp[j]);
+        for (j = 0; j < SIZE_TOPICNAME/2; j++) {
+            snprintf(&topicname_current[2*j], sizeof(topicname_current)-(2*j), "%02x", topicname_tmp[j]);
         }
         bytes_read = strlcpy(&topics[iteration][0], topicname_current, SIZE_TOPICNAME+1);
-        if ( bytes_read < SIZE_TOPICNAME ) {
+        if (bytes_read < SIZE_TOPICNAME) {
             printf("Failed: strlcpy topicname->iteration, read %lu, expected %lu\n", bytes_read, SIZE_TOPICNAME);
             returncode = 6;
             goto exit_close;
@@ -113,21 +113,21 @@ int main(int argc, char** argv, char** envp) {
     /*
     memset(deviceid1, 0, sizeof deviceid1);
     bytes_read = fread(deviceid1, 1, sizeof deviceid1, urand_fd);
-    if ( bytes_read < sizeof deviceid1 ) {
+    if (bytes_read < sizeof deviceid1) {
         printf("Failed: generating deviceid bytes read %lu, expected %lu\n", bytes_read, sizeof deviceid1);
         returncode = 4;
         goto exit_close;
     }*/
 
     /* set some device keys */
-    for ( iteration=0; iteration < NUM_PKCATS; iteration++ ) { 
+    for (iteration=0; iteration < NUM_PKCATS; iteration++) { 
         e4c_set_device_key(&store, pkkat[iteration].otherdeviceid, pkkat[iteration].otherdevicepk);
     }
 
     /* test sync and reload from file-based storage */
     e4c_sync(&store);
 #ifdef E4_STORE_FILE
-    memset(&store, 0, sizeof store);
+    memset(&store, 0, sizeof(store));
 #endif
     e4c_load(&store, "/tmp/unittestspk.e4c");
 
@@ -136,13 +136,13 @@ int main(int argc, char** argv, char** envp) {
     uint8_t c2_pubkey_reread[32];
 
     e4retcode = e4c_get_c2_pubkey(&store, c2_pubkey_reread);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to get c2 pubkey\n");
         returncode = 1;
         goto exit_close;
     }
 
-    if ( memcmp(c2_pubkey_reread, pkkat[0].c2_edwards_pubkey, sizeof pkkat[0].c2_edwards_pubkey) != 0 ) {
+    if (memcmp(c2_pubkey_reread, pkkat[0].c2_edwards_pubkey, sizeof(pkkat[0].c2_edwards_pubkey)) != 0) {
         printf("Failed: we reread the c2 pubkey and it was invalid\n");
         returncode = 1;
         goto exit_close;

--- a/test/siv.c
+++ b/test/siv.c
@@ -39,40 +39,40 @@ typedef struct _e4_aessiv_kat {
     */ 
     size_t failures = 0;
 
-    for ( int i = 0; i < SIV_KAT_NUM; i++ ) {
+    for (int i = 0; i < SIV_KAT_NUM; i++) {
 
         uint8_t generated_ct[116] = {0};
         uint8_t recovered_pt[100] = {0};
         size_t ptlen = 100;
         size_t ctlen = 116;
 
-        if ( aes256_encrypt_siv(generated_ct, &ctlen, 
-                    siv_kats[i].ad, sizeof siv_kats[i].ad,
-                    siv_kats[i].plaintext, sizeof siv_kats[i].plaintext, 
-                    siv_kats[i].key) != 0 )
+        if (aes256_encrypt_siv(generated_ct, &ctlen, 
+                    siv_kats[i].ad, sizeof(siv_kats[i].ad),
+                    siv_kats[i].plaintext, sizeof(siv_kats[i].plaintext), 
+                    siv_kats[i].key) != 0)
         {
             printf("encrypt-siv func failure ");
             failures += 1;
             continue;
         }
                     
-        if ( memcmp(generated_ct, siv_kats[i].ciphertext, sizeof generated_ct) != 0 ) {
+        if (memcmp(generated_ct, siv_kats[i].ciphertext, sizeof(generated_ct)) != 0) {
             printf("encrypt-siv output failure ");
             failures += 1;
             continue;
         }
 
-        if ( aes256_decrypt_siv(recovered_pt, &ptlen, 
-                    siv_kats[i].ad, sizeof siv_kats[i].ad,
-                    siv_kats[i].ciphertext, sizeof siv_kats[i].ciphertext,
-                    siv_kats[i].key) != 0 )
+        if (aes256_decrypt_siv(recovered_pt, &ptlen, 
+                    siv_kats[i].ad, sizeof(siv_kats[i].ad),
+                    siv_kats[i].ciphertext, sizeof(siv_kats[i].ciphertext),
+                    siv_kats[i].key) != 0)
         {
             printf("decrypt-siv func failure ");
             failures += 1;
             continue;
         }
 
-        if ( memcmp(recovered_pt, siv_kats[i].plaintext, sizeof recovered_pt) != 0 ) {
+        if (memcmp(recovered_pt, siv_kats[i].plaintext, sizeof(recovered_pt)) != 0) {
             printf("decrypt-siv output failure ");
             failures += 1;
             continue;

--- a/test/symkey/symkey_file.c
+++ b/test/symkey/symkey_file.c
@@ -31,10 +31,10 @@ int main(int argc, char** argv, char** envp) {
 
     char topics[NUM_TOPICS][SIZE_TOPICNAME+1];
 
-    memset(&store, 0, sizeof store);
+    memset(&store, 0, sizeof(store));
 
     urand_fd = fopen("/dev/urandom", "r");
-    if ( urand_fd == NULL  ) {
+    if (urand_fd == NULL) {
         /* can't generate random plaintexts in this case */
         printf("Failed: unable to open /dev/urandom\n");
         returncode = 1;
@@ -42,7 +42,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     e4retcode = e4c_init(&store);
-    if ( e4retcode != 0 ) {
+    if (e4retcode != 0) {
         printf("Failed: unable to init e4store\n");
         returncode = 1;
         goto exit_close;
@@ -51,15 +51,15 @@ int main(int argc, char** argv, char** envp) {
     e4c_set_storagelocation(&store, "/tmp/unittests.e4c");
 
     /* set the identity key */
-    bytes_read = fread(&clientid, 1, sizeof clientid, urand_fd);
-    if ( bytes_read < sizeof clientid ) {
-        printf("Failed: generating clientid bytes read %lu, expected %lu\n", bytes_read, sizeof clientid);
+    bytes_read = fread(&clientid, 1, sizeof(clientid), urand_fd);
+    if (bytes_read < sizeof(clientid)) {
+        printf("Failed: generating clientid bytes read %lu, expected %lu\n", bytes_read, sizeof(clientid));
         returncode = 2;
         goto exit_close;
     }
-    bytes_read = fread(clientkey, 1, sizeof clientkey, urand_fd);
-    if ( bytes_read < sizeof clientkey ) {
-        printf("Failed: generating clientkey bytes read %lu, expected %lu\n", bytes_read, sizeof clientid);
+    bytes_read = fread(clientkey, 1, sizeof(clientkey), urand_fd);
+    if (bytes_read < sizeof(clientkey)) {
+        printf("Failed: generating clientkey bytes read %lu, expected %lu\n", bytes_read, sizeof(clientid));
         returncode = 3;
         goto exit_close;
     }
@@ -67,32 +67,32 @@ int main(int argc, char** argv, char** envp) {
     e4retcode = e4c_set_id(&store, clientid);
     e4retcode = e4c_set_idkey(&store, clientkey);
 
-    for ( iteration = 0; iteration<NUM_TOPICS; iteration++ ) {
+    for (iteration = 0; iteration<NUM_TOPICS; iteration++) {
 
         int j=0;
 
         memset(topics[iteration], 0, SIZE_TOPICNAME);
-        memset(topicname_current, 0, sizeof topicname_current);
-        memset(topickey_current, 0, sizeof topickey_current);
+        memset(topicname_current, 0, sizeof(topicname_current));
+        memset(topickey_current, 0, sizeof(topickey_current));
 
-        bytes_read = fread(topickey_current, 1, sizeof topickey_current, urand_fd);
-        if ( bytes_read < sizeof topickey_current ) {
-            printf("Failed: generating topickey_current bytes read %lu, expected %lu\n", bytes_read, sizeof topickey_current);
+        bytes_read = fread(topickey_current, 1, sizeof(topickey_current), urand_fd);
+        if (bytes_read < sizeof(topickey_current)) {
+            printf("Failed: generating topickey_current bytes read %lu, expected %lu\n", bytes_read, sizeof(topickey_current));
             returncode = 4;
             goto exit_close;
         }
         bytes_read = fread(topicname_tmp, 1, SIZE_TOPICNAME/2, urand_fd);
-        if ( bytes_read < sizeof topicname_tmp ) {
+        if (bytes_read < sizeof(topicname_tmp)) {
             printf("Failed: generating topicname bytes read %lu, expected %lu\n", bytes_read, SIZE_TOPICNAME/2);
             returncode = 5;
             goto exit_close;
         }
 
-        for ( j = 0; j < SIZE_TOPICNAME/2; j++ ) {
-            snprintf(&topicname_current[2*j], (sizeof topicname_current)-(2*j), "%02x", topicname_tmp[j]);
+        for (j = 0; j < SIZE_TOPICNAME/2; j++) {
+            snprintf(&topicname_current[2*j], (sizeof(topicname_current))-(2*j), "%02x", topicname_tmp[j]);
         }
         bytes_read = strlcpy(&topics[iteration][0], topicname_current, SIZE_TOPICNAME+1);
-        if ( bytes_read < SIZE_TOPICNAME ) {
+        if (bytes_read < SIZE_TOPICNAME) {
             printf("Failed: strlcpy topicname->iteration, read %lu, expected %lu\n", bytes_read, SIZE_TOPICNAME);
             returncode = 6;
             goto exit_close;
@@ -105,14 +105,14 @@ int main(int argc, char** argv, char** envp) {
     /* test sync and reload from file-based storage */
     e4c_sync(&store);
 #ifdef E4_STORE_FILE
-    memset(&store, 0, sizeof store);
+    memset(&store, 0, sizeof(store));
 #endif
     e4c_load(&store, "/tmp/unittests.e4c");
 
     /* TODO: test control messages have their intended effect. */
 
     /* Test E4 encryption using random topic keys */
-    for ( iteration = 0; iteration<ITER_MAX; iteration++) {
+    for (iteration = 0; iteration<ITER_MAX; iteration++) {
 
 
         size_t bytes_read = 0;
@@ -125,8 +125,8 @@ int main(int argc, char** argv, char** envp) {
 
         char* topicname;
 
-        bytes_read = fread(&topicindex, 1, sizeof topicindex, urand_fd);
-        if ( bytes_read < sizeof topicindex ) {
+        bytes_read = fread(&topicindex, 1, sizeof(topicindex), urand_fd);
+        if (bytes_read < sizeof(topicindex)) {
             printf("Failed: unable to read byte for topicindex");
             returncode = 7;
             goto exit_close;
@@ -139,7 +139,7 @@ int main(int argc, char** argv, char** envp) {
         memset(recovered_buffer, 0, PT_MAX+1);
 
         bytes_read = fread(plaintext_buffer, 1, PT_MAX, urand_fd);
-        if ( bytes_read < PT_MAX ) {
+        if (bytes_read < PT_MAX) {
             printf("Failed: unable to read random plaintext. Asked for %lu bytes, got %lu\n", PT_MAX, bytes_read);
             returncode = 8;
             goto exit_close;
@@ -154,7 +154,7 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        if ( ciphertext_len != PT_MAX + E4_MSGHDR_LEN ) {
+        if (ciphertext_len != PT_MAX + E4_MSGHDR_LEN) {
             printf("Failed: decrypted ciphertext has length %lu, should be %lu\n", ciphertext_len, PT_MAX+E4_MSGHDR_LEN);
             returncode = 9;
             goto exit_close;
@@ -172,14 +172,14 @@ int main(int argc, char** argv, char** envp) {
             goto exit_close;
         }
 
-        if ( recovered_len != PT_MAX ) {
+        if (recovered_len != PT_MAX) {
             printf("Failed: decrypted plaintext has length %lu, should be %lu\n", recovered_len, PT_MAX);
             returncode = 10;
             goto exit_close;
         }
 
 
-        if ( memcmp(recovered_buffer, plaintext_buffer, sizeof plaintext_buffer) != 0 ) {
+        if (memcmp(recovered_buffer, plaintext_buffer, sizeof(plaintext_buffer)) != 0) {
             printf("Failed: recovered buffer not equal to plaintext buffer.\n");
             returncode = 11;
             goto exit_close;

--- a/test/util.c
+++ b/test/util.c
@@ -13,12 +13,12 @@ int main(int argc, char** argv, char** envp) {
     int r = 0;
 
     r = e4c_hex_decode((char*)test1_bytes_output, sizeof(test1_bytes_output), test1_input, strlen(test1_input));
-    if ( r == 0 ) {
+    if (r == 0) {
         returncode = 1;
         goto exit;
     }
 
-    if ( memcmp(test1_bytes_output, test1_bytes_kat, sizeof test1_bytes_kat) != 0 ) {
+    if (memcmp(test1_bytes_output, test1_bytes_kat, sizeof(test1_bytes_kat)) != 0) {
         printf("Test %s failed.", "Test1");
 
 


### PR DESCRIPTION
Automated find and replace in-place with:

* perl -pi -e 's/ \)/\)/' *
* perl -pi -e 's/\( /\(/' *

to make for more consistent code to improve
readability.

Also made consistent of invoking

    sizeof(expr)

instead of

    sizeof expr

Fixes #12