### PR TITLE
Implement precomputed pubkey for C2/device. Resolves #19.

### DIFF
--- a/include/e4/e4.h
+++ b/include/e4/e4.h
@@ -174,6 +174,9 @@ int e4c_unprotect_message(uint8_t *message,
                           e4storage *storage,
                           const uint32_t proto_opts);
 
+#ifdef E4_MODE_PUBKEY
+int e4c_pubkey_c2sharedsecret_derivestore(e4storage* storage);
+#endif
 
 /* the e4storage type pre-defined above implements these API calls */
 int e4c_init(e4storage *store);
@@ -197,6 +200,11 @@ int e4c_set_idpubkey(e4storage *store, const uint8_t *pubkey);
 int e4c_set_idseckey(e4storage *store, const uint8_t *key);
 int e4c_get_idseckey(e4storage* store, uint8_t *key);
 int e4c_get_idpubkey(e4storage* store, uint8_t *key);
+
+/* APIs to store and retrieve the C2 shared secret */
+int e4c_set_c2sharedsecret(e4storage* store, const uint8_t* key);
+int e4c_get_c2sharedsecret(e4storage* store, uint8_t* key);
+
 int e4c_getdeviceindex(e4storage *store, const uint8_t* id);
 int e4c_getdevicekey(uint8_t* key, e4storage *store, const int index);
 int e4c_set_device_key(e4storage *store, const uint8_t *id, const uint8_t *key);

--- a/include/e4/internal/e4c_pk_store_file.h
+++ b/include/e4/internal/e4c_pk_store_file.h
@@ -50,6 +50,8 @@ struct _e4storage
     uint8_t pubkey[E4_PK_EDDSA_PUBKEY_LEN];
     uint8_t c2key[E4_PK_X25519_PUBKEY_LEN];
 
+    uint8_t c2sharedkey[E4_KEY_LEN];
+
     uint16_t devicecount;
     uint16_t topiccount;
 

--- a/include/e4/internal/e4c_pk_store_mem.h
+++ b/include/e4/internal/e4c_pk_store_mem.h
@@ -32,6 +32,8 @@ struct _e4storage
     uint8_t pubkey[E4_PK_EDDSA_PUBKEY_LEN];
     uint8_t c2key[E4_PK_X25519_PUBKEY_LEN];
 
+    uint8_t c2sharedkey[E4_KEY_LEN];
+
     uint16_t devicecount;
     uint16_t topiccount;
 

--- a/include/e4/util.h
+++ b/include/e4/util.h
@@ -39,6 +39,9 @@ extern "C" {
 /* void zeroize */
 void zeroize(void *v, size_t n);
 
+/* check buffer is zero */
+size_t zerocheck(void* v, size_t n);
+
 /* Derives a ClientID. Depends on the constant E4_ID_LEN */
 int e4c_derive_clientid(uint8_t *clientid, const size_t clientidlen, const char *clientname, const size_t clientnamelen);
 

--- a/src/e4c_pk_store_mem.c
+++ b/src/e4c_pk_store_mem.c
@@ -75,8 +75,13 @@ exit:
 
 int e4c_set_idseckey(e4storage *store, const uint8_t *key)
 {
+    size_t c2keynotempty = 0;
     memmove(store->privkey, key, sizeof(store->privkey));
     e4c_sync(store);
+    c2keynotempty = zerocheck(store->c2key, sizeof(store->c2key));
+    if (c2keynotempty) {
+        e4c_pubkey_c2sharedsecret_derivestore(store);
+    }
     return E4_RESULT_OK;
 }
 
@@ -299,13 +304,36 @@ int e4c_reset_devices(e4storage* store)
 }
 
 int e4c_set_c2_pubkey(e4storage* store, const uint8_t* key) {
+    size_t devicekeynotempty = 0;
     memcpy(store->c2key, key, E4_PK_X25519_PUBKEY_LEN);
     e4c_sync(store);
-    return 0;
+    devicekeynotempty = zerocheck(store->privkey, sizeof(store->privkey));
+    if (devicekeynotempty) {
+        e4c_pubkey_c2sharedsecret_derivestore(store);
+    }
+    return E4_RESULT_OK;
 }
 
 int e4c_get_c2_pubkey(e4storage* store, uint8_t* key) {
+    size_t empty = zerocheck(store->c2key, sizeof(store->c2key));
+    if (empty == 0) {
+        return E4_ERROR_PERSISTENCE_ERROR;
+    }
     memcpy(key, store->c2key, E4_PK_X25519_PUBKEY_LEN);
+    return 0;
+}
+
+int e4c_set_c2sharedsecret(e4storage* store, const uint8_t* key) {
+    memcpy(store->c2sharedkey, key, E4_KEY_LEN);
+    return 0;
+}
+
+int e4c_get_c2sharedsecret(e4storage* store, uint8_t* key) {
+    size_t empty = zerocheck(store->c2sharedkey, sizeof(store->c2sharedkey));
+    if (empty == 0) {
+        return E4_ERROR_PERSISTENCE_ERROR;
+    }
+    memcpy(key, store->c2sharedkey, E4_KEY_LEN);
     return 0;
 }
 

--- a/src/e4util.c
+++ b/src/e4util.c
@@ -30,6 +30,16 @@ void zeroize(void *v, size_t n)
     while(n--) *p++ = 0;
 }
 
+size_t zerocheck(void* v, size_t n) {
+
+    size_t sum = 0;
+    volatile unsigned char* p = (volatile unsigned char *)v;
+    while(n--) {
+        sum |= *p++;
+    }
+    return sum;
+}
+
 int e4c_derive_clientid(uint8_t *clientid, const size_t clientidlen, const char *clientname, const size_t clientnamelen)
 {
     if (clientidlen != E4_ID_LEN) {

--- a/test/crypto.c
+++ b/test/crypto.c
@@ -9,18 +9,17 @@ int main(int argc, char** argv, char** envp) {
 
     int r_sha3, r_shake, r_aes, r_siv, result = 0;
 
-	printf("LIBE4 Crypto Implementation Testing.\n\n");
-    
+	printf("LIBE4 Crypto Implementation Testing.\n");    
     r_sha3 = test_sha3(); result += r_sha3;
-    printf("Testing SHA3 (ALL):\t\t%s\n", r_sha3 != 0 ? "failed" : "ok");
+    printf("Testing SHA3 (ALL):\t\t%s\n", r_sha3 != 0 ? "Failed" : "OK");
     r_shake = test_shake(); result += r_shake;
-    printf("Testing SHAKE (ALL):\t\t%s\n", r_shake != 0 ? "failed" : "ok");
+    printf("Testing SHAKE (ALL):\t\t%s\n", r_shake != 0 ? "Failed" : "OK");
     r_aes = test_aes256(); result += r_aes;
-    printf("Testing AES-256:\t\t%s\n", r_aes != 0 ? "failed" : "ok");
+    printf("Testing AES-256:\t\t%s\n", r_aes != 0 ? "Failed" : "OK");
     r_siv = test_aes_siv(); result += r_siv;
-    printf("Testing SIV-AES-256:\t\t%s\n", r_siv != 0 ? "failed" : "ok");
+    printf("Testing SIV-AES-256:\t\t%s\n", r_siv != 0 ? "Failed" : "OK");
     
     printf("\n");
-	printf("Tests %s\n", result == 0 ? "Passed" : "Failed");
+	printf("Tests %s\n", result == 0 ? "OK" : "Failed");
     return result;
 }

--- a/test/pubkey/pubkey_crypto_test.c
+++ b/test/pubkey/pubkey_crypto_test.c
@@ -33,11 +33,9 @@ int main(int argc, char** argv) {
         printf("\n");
         printhex(pkkat[0].c2_montgom_seckey, sizeof(pkkat[0].c2_montgom_seckey));
         printf("\n");
-
-        //return 1;
-    } else {
-        printf("c25519_privkey_convert: OK.\n");
-    }
+        
+        return 1;
+    };
 
     uint8_t c2_c255_pubkey[32] = {0};
 
@@ -52,10 +50,8 @@ int main(int argc, char** argv) {
         printhex(pkkat[0].c2_montgom_pubkey, sizeof(pkkat[0].c2_montgom_pubkey));
         printf("\n");
 
-        //return 1;
-    } else {
-        printf("c25519_pubkey_convert: OK.\n");
-    }
+        return 1;
+    };
 
     // curve25519 variant c2->device:
     
@@ -74,9 +70,7 @@ int main(int argc, char** argv) {
         printhex(pkkat[0].dev_sharedkey, sizeof(pkkat[0].dev_sharedkey));
         printf("\n");
 
-        //return 1;
-    } else {
-        printf("c25519_kex_c2d: OK.\n");
+        return 1;
     }
     
     // curve25519 variant c2->device:
@@ -96,11 +90,11 @@ int main(int argc, char** argv) {
         printhex(pkkat[0].dev_sharedkey, sizeof(pkkat[0].dev_sharedkey));
         printf("\n");
 
-        //return 1;
-    } else {
-        printf("c25519_kex_d2c: OK.\n");
+        return 1;
     }
     }
+
+    printf("Curve25519 tests: OK\n");
 
     return 0;
 }

--- a/test/pubkey/pubkey_e4cmd_test.c
+++ b/test/pubkey/pubkey_e4cmd_test.c
@@ -107,6 +107,26 @@ int main(int argc, char** argv, char** envp) {
             returncode = 1;
             goto exit_close;
         }
+
+
+        /* now we have access to the shared key as a result of the dumb 
+         * optimisation, let's check that vs the KAT as well */
+
+        if ( memcmp(store.c2sharedkey, pkkat[i].c2_sharedkey, sizeof(pkkat[i].c2_sharedkey)) != 0 ) {
+            printf("Failed: libe4 has not derived correct sharedkey;\n");
+            printf("        Further tests are pretty much useless.\n");
+            for ( int j = 0; j < E4_KEY_LEN; j++ ) {
+                printf("0x%02x ", store.c2sharedkey[j]);
+            }
+            printf("\n");
+            for ( int j = 0; j < E4_KEY_LEN; j++ ) {
+                printf("0x%02x ", pkkat[i].c2_sharedkey[j]);
+            }
+            printf("\n");
+            returncode = 1;
+            goto exit_close;
+        }
+
         /* now we are set up, let's try processing those command messages */
 
         memset(messagebuffer, 0, sizeof(messagebuffer));

--- a/test/pubkey/pubkey_e4cmd_test.c
+++ b/test/pubkey/pubkey_e4cmd_test.c
@@ -250,6 +250,8 @@ int main(int argc, char** argv, char** envp) {
         }
     }
 
+    printf("e4 pubkey command message tests: OK\n");
+
 exit_close:
     fclose(urand_fd);
 exit:

--- a/test/pubkey/pubkey_e4topicmsg_test.c
+++ b/test/pubkey/pubkey_e4topicmsg_test.c
@@ -146,6 +146,8 @@ int main(int argc, char** argv, char** envp) {
         }
     }
 
+    printf("e4 pubkey topic message tests: OK\n");
+
 exit_close:
     fclose(urand_fd);
 exit:

--- a/test/pubkey/pubkey_filestore_test.c
+++ b/test/pubkey/pubkey_filestore_test.c
@@ -149,6 +149,8 @@ int main(int argc, char** argv, char** envp) {
 
     }
 
+    printf("e4 pubkey store test. OK\n");
+
 exit_close:
     fclose(urand_fd);
 exit:

--- a/test/siv.c
+++ b/test/siv.c
@@ -10,33 +10,6 @@
 
 int main(int argc, char** argv, char** envp) {
 
-	printf("LIBE4 AES-SIV Compatibility testing.\n\n");
-
-    /*int aes256_encrypt_siv(uint8_t *ct,
-                       size_t *ctlen, 
-                       const uint8_t *ad,
-                       size_t adlen, 
-                       const uint8_t *pt,
-                       size_t ptlen,  
-                       const uint8_t *key);
-
-      int aes256_decrypt_siv(uint8_t *pt,
-                       size_t *ptlen, 
-                       const uint8_t *ad,
-                       size_t adlen, 
-                       const uint8_t *ct,
-                       size_t ctlen, 
-                       const uint8_t *key);
-
-typedef struct _e4_aessiv_kat {
-    const uint8_t ciphertext[116];
-    const uint8_t plaintext[100];
-    const uint8_t ad[32];
-	const uint8_t key[32];
-} e4_aessiv_kat;
-
-
-    */ 
     size_t failures = 0;
 
     for (int i = 0; i < SIV_KAT_NUM; i++) {
@@ -79,7 +52,7 @@ typedef struct _e4_aessiv_kat {
         }
     }
     printf("\n");
-    printf("SIV test executed %d KATs, with %ld failures\n", SIV_KAT_NUM, failures);
+    printf("SIV test: (executed %d KATs, with %ld divergences) %s\n", SIV_KAT_NUM, failures, failures==0 ? "OK" : "Failed");
 
     return failures > 0 ? 1 : 0;
 }

--- a/test/util.c
+++ b/test/util.c
@@ -63,7 +63,7 @@ int main(int argc, char** argv, char** envp) {
         printf("Util tests: OK\n");
     }
     else {
-        printf("Util tests: FAILED\n");
+        printf("Util tests: Failed\n");
     }
     return returncode;
 }

--- a/test/util.c
+++ b/test/util.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "e4/util.h"
 
-int main(int argc, char** argv, char** envp) {
+int hextest() {
     int returncode = 0;
     char test1_input[] = "DEADBEEF";
     unsigned char test1_bytes_kat[4] = {0xDE, 0xAD, 0xBE, 0xEF};
@@ -19,12 +19,51 @@ int main(int argc, char** argv, char** envp) {
     }
 
     if (memcmp(test1_bytes_output, test1_bytes_kat, sizeof(test1_bytes_kat)) != 0) {
-        printf("Test %s failed.", "Test1");
+        printf("HEXTEST: Test %s failed.\n", "Test1");
 
 
         returncode = 1;
         goto exit;
     }
+/* fallthrough ok*/
 exit:
+    return returncode;
+}
+
+int zerochecktest() {
+    
+    size_t check_inner = 0;
+    size_t check_outer = 0;
+    int returncode = 0;
+    unsigned char testbuffer[6] = {0xA0, 0x00, 0x00, 0x00, 0x00, 0xA0};
+    
+    check_inner = zerocheck(&testbuffer[1], 4);
+    if ( check_inner != 0 ) {
+        printf("ZEROCHECK: overflow or underflow in zerocheck.\n");
+        returncode = 1; goto exit;
+    }
+
+    check_outer = zerocheck(&testbuffer[0], 6);
+    if ( check_outer == 0 ) {
+        printf("ZEROCHECK: non-zero buffer reported as zero.\n");
+        returncode = 1; goto exit;
+    }
+
+/* fallthrough ok*/
+exit:
+    return returncode;
+}
+
+int main(int argc, char** argv, char** envp) {
+
+    int returncode = 0;
+    returncode += hextest();
+    returncode += zerochecktest();
+    if ( returncode == 0 ) {
+        printf("Util tests: OK\n");
+    }
+    else {
+        printf("Util tests: FAILED\n");
+    }
     return returncode;
 }


### PR DESCRIPTION
Logically, this implementation will derive an in-memory shared secret
for the C2/device channel under the following conditions:

 * On load from storage.
 * On setting the C2 public key if the device key is already set.
 * On setting the device secret key if the C2 public key is set.

 For these purposes, "already set" is interpreted as "not all zero
 bytes" as a best-effort interpretation.

 Storages are responsible for implementing this behaviour by calling the
 appropriate e4c functions (now added).