### PR TITLE
Implement code size count from makefile.

### DIFF
--- a/mk/conf.mk
+++ b/mk/conf.mk
@@ -34,9 +34,18 @@ ifeq ("$(STORE)", "file")
 CONFIG_DEFINES += -DE4_STORE_FILE
 endif
 
+# tools for specific workflows (so their location can be custom)
+CLANGTIDY ?= clang-tidy
+
+codesize: lib
+	@$(eval CODESIZE=`wc -c < "$(LIB)"`)
+	@echo "Code size in current configuration:"
+	@echo "$(CODESIZE)"
+
 
 .PHONY postbuild_config_echo:
 	$(info Build Successful)
+	@$(eval CODESIZE=`wc -c < "$(LIB)"`)
 	@echo ""
 	@echo "================================================================================="
 	@echo ""
@@ -54,4 +63,8 @@ ifeq ("$(CONF)", "all")
 	@echo "Shared Library: $(LIBSO)"
 endif
 	@echo ""
+	@echo "*** Code Size (static lib) in bytes: $(CODESIZE) ***"
+	@echo ""
 	@echo "================================================================================="
+
+

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -47,7 +47,7 @@ format:
 	clang-format -i src/*.c src/crypto/*.c include/e4/*.h include/e4/crypto/*.h include/e4/internal/*.h
 
 tidy: setup $(BUILDDIR)/include/e4config/e4_config.h
-	clang-tidy -checks="-*,clang-analyzer-core.*" $(SRCS) -- $(CFLAGS) $(INCLUDES) $(CONFIG_DEFINES)
+	$(CLANGTIDY) -checks="-*,clang-analyzer-core.*" $(SRCS) -- $(CFLAGS) $(INCLUDES) $(CONFIG_DEFINES)
 
 checksec:
 	checksec --format=cli --file=build/all/lib/libe4.so.1.0.0


### PR DESCRIPTION
This commit uses the portable POSIX solution for counting the size of
the output library (.a), namely wc -c.
The output is specifically produced in the successful "end of make"
message.
Alternatively, one can now explicitly "make codesize".

We should specifically note that: code size will depend on target
architecture (x86_64 has 8-byte pointers, for example) and does not
account for the extraction of the various elf-objects. That is, this
code currently gives an upper bound estimate of the size INCLUDING **ELF**
metadata and symbols for each and every file in the archive. A release
image would strip all this information.